### PR TITLE
Fix: a weekdayRangeFull may have several lists and ranges

### DIFF
--- a/src/OsmStringToOpeningHoursConverter.php
+++ b/src/OsmStringToOpeningHoursConverter.php
@@ -153,30 +153,24 @@ class OsmStringToOpeningHoursConverter
             }
         }
         $weekdays = [];
+        foreach (explode(',', $weekdayRangeFull) as $match) {
+            if (str_contains($match, '-')) {
+                [$weekdayStart, $weekdayEnd] = explode('-', $match);
+                $startIndex = array_search($weekdayStart, $weekDayNamesShort, true);
+                $endIndex = !empty($weekdayEnd) ? array_search($weekdayEnd, $weekDayNamesShort, true) : $startIndex;
 
-        if ($isRange) {
-            [$weekdayStart, $weekdayEnd] = explode('-', $weekdayRangeFull);
-            $startIndex = array_search($weekdayStart, $weekDayNamesShort, true);
-            $endIndex = !empty($weekdayEnd) ? array_search($weekdayEnd, $weekDayNamesShort, true) : $startIndex;
-
-            for ($i = $startIndex; $i <= $endIndex; $i++) {
-                $weekdays[self::WEEKDAYS[$weekDayNamesShort[$i]]] = $hoursValue;
+                for ($i = $startIndex; $i <= $endIndex; $i++) {
+                    $weekdays[self::WEEKDAYS[$weekDayNamesShort[$i]]] = $hoursValue;
+                }
+            } else {
+                $listOfDays = explode(',', $match);
+                foreach ($listOfDays as $day) {
+                    $weekdays[self::WEEKDAYS[$day]] = $hoursValue;
+                }
             }
-
-            return $weekdays;
         }
 
-        if ($isList) {
-            $listOfDays = explode(',', $weekdayRangeFull);
-            foreach ($listOfDays as $day) {
-                $weekdays[self::WEEKDAYS[$day]] = $hoursValue;
-            }
-
-            return $weekdays;
-        }
-
-        // single day
-        return [self::WEEKDAYS[$weekdayRangeFull] => $hoursValue];
+        return $weekdays;
     }
 
     protected static function parseException(string $ruleSet): array

--- a/tests/OsmStringToOpeningHoursConverterTest.php
+++ b/tests/OsmStringToOpeningHoursConverterTest.php
@@ -48,6 +48,16 @@ class OsmStringToOpeningHoursConverterTest extends TestCase
                     'sunday'   => ['00:00-24:00'],
                 ]
             ],
+            'Multiple lists and ranges'                                                            => [
+                'osmString' => 'Mo,Th-Fr,Su 12:00-13:30,19:00-21:00; Sa 12:00-13:30,19:00-21:01',
+                'expected'  => [
+                    'monday'    => ['12:00-13:30', '19:00-21:00'],
+                    'thursday'  => ['12:00-13:30', '19:00-21:00'],
+                    'friday'    => ['12:00-13:30', '19:00-21:00'],
+                    'saturday'  => ['12:00-13:30', '19:00-21:01'],
+                    'sunday'    => ['12:00-13:30', '19:00-21:00'],
+                ],
+            ],
             'Mo-Sa 10-20; Tu 10-14'                                                                => [
                 'osmString' => 'Mo-Sa 10:00-20:00; Tu 10:00-14:00',
                 'expected'  => [


### PR DESCRIPTION
This PR allows to have several lists and ranges in the `$weekdayRangeFull`. For example: `Mo,Th-Fr,Su`